### PR TITLE
Add rough first pass at the option to obfuscate values

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,9 +48,10 @@ SteamclEnv comes with a number of flags to customize code generation:
 
 | Command | Short | Description |
 | ------ | ------ | ---------- |
-| --path | -p | Path to your environment file, relative to the current directory. This overrides --dev. |
-| --dev | -d | Use .env.dev rather than .env. This is superseded by --path if provided. |
 | --debug | n/a | Toggle debug mode, which prints more information out to the console while running. |
+| --dev | -d | Use .env.dev rather than .env. This is superseded by --path if provided. |
+| --obfuscate | -o | Obfuscates environment values. See the README for more information. |
+| --path | -p | Path to your environment file, relative to the current directory. This overrides --dev. |
 
 ### Interfacing with Bitrise
 
@@ -58,8 +59,8 @@ SteamclEnv comes with a number of flags to customize code generation:
 
 ### Obfuscation
 
-https://nshipster.com/secrets/
+Inspired by the folks at [NSHipster](https://nshipster.com/secrets/), this options obfuscates the values written out to your `Environment.swift` file, and provides some extra output to decode those values.
 
 ## License
 
-Netable is available under the MIT license. See [LICENSE.md](https://github.com/steamclock/steamclenv/blob/main/LICENSE.md) for more info.
+SteamclEnv is available under the MIT license. See [LICENSE.md](https://github.com/steamclock/steamclenv/blob/main/LICENSE.md) for more info.

--- a/Sources/steamclenv/EnvironmentGenerator.swift
+++ b/Sources/steamclenv/EnvironmentGenerator.swift
@@ -20,10 +20,10 @@ struct EnvironmentGenerator {
     """
 
     let entries: [String: String]
-    let debug: Bool
+    let obfuscate: Bool
 
-    init(_ envContents: String, debug: Bool) throws {
-        self.debug = debug
+    init(_ envContents: String, obfuscate: Bool) throws {
+        self.obfuscate = obfuscate
 
         let lines = envContents.components(separatedBy: .newlines)
         entries = lines.reduce(into: [String: String]()) { dict, line in
@@ -31,7 +31,8 @@ struct EnvironmentGenerator {
             if split.count == 2 {
                 let key = "\(split[0])"
                 let value = "\(split[1])"
-                if debug { print("Found key: \(key)") }
+
+                Logger.shared.log("Found key: \(key)")
                 dict[key] = value
             }
         }
@@ -42,9 +43,23 @@ struct EnvironmentGenerator {
     var fileContents: String {
         var contents = fileHeader
 
-        entries.forEach { key, value in
-            contents += "    static let \(key) = \"\(value)\" \n"
+        if obfuscate {
+            Logger.shared.log("Generating obfuscated Environment file...")
+            let obfuscator = ValueObfuscator()
+
+            contents += obfuscator.saltOutput
+
+            entries.forEach {
+                contents += obfuscator.obfuscated(key: $0, value: $1)
+            }
+        } else {
+            Logger.shared.log("Generating Environment file...")
+            entries.forEach { key, value in
+                contents += "    static let \(key) = \"\(value)\" \n"
+            }
         }
+
+        Logger.shared.log("Added \(entries.keys.count) entried to Environment 🚀")
 
         contents += fileFooter
 

--- a/Sources/steamclenv/Logger.swift
+++ b/Sources/steamclenv/Logger.swift
@@ -1,0 +1,21 @@
+//
+//  Logger.swift
+//  
+//
+//  Created by Brendan Lensink on 2023-03-23.
+//
+
+import Foundation
+
+struct Logger {
+    static var shared = Logger()
+
+    var isDebug = false
+
+    private init() {}
+
+    func log(_ message: String) {
+        if isDebug { print(message) }
+    }
+}
+

--- a/Sources/steamclenv/ValueObfuscator.swift
+++ b/Sources/steamclenv/ValueObfuscator.swift
@@ -1,0 +1,54 @@
+//
+//  ValueObfuscator.swift
+//  
+//
+//  Created by Brendan Lensink on 2023-03-23.
+//
+
+import Foundation
+import os
+
+struct ValueObfuscator {
+    private let salt: [UInt8]
+
+    init() {
+        var seed = UInt64.random(in: 0...UInt64.max)
+        let bytePtr = withUnsafePointer(to: &seed) {
+            $0.withMemoryRebound(to: UInt8.self, capacity: MemoryLayout<UInt64>.size) {
+                UnsafeBufferPointer(start: $0, count: MemoryLayout<UInt64>.size)
+            }
+        }
+
+        self.salt = Array(bytePtr)
+    }
+
+    var saltOutput: String {
+        """
+            private static let salt: [UInt8] = \(salt)
+
+            private static func decode(_ encoded: [UInt8]) -> String {
+              String(decoding: encoded.enumerated().map { (offset, element) in
+                      element ^ salt[offset % salt.count]
+                  }, as: UTF8.self
+              )
+            }\n
+        """
+    }
+
+    func obfuscated(key: String, value: String) -> String {
+        """
+            static var \(key): String {
+                let encoded: [UInt8] = \(self.encode(value))
+                return decode(encoded)
+            }\n
+        """
+    }
+
+    private func encode(_ value: String) -> [UInt8] {
+        let encoded = value.enumerated().map { offset, token in
+            token.asciiValue! ^ salt[offset % salt.count]
+        }
+
+        return encoded
+    }
+}

--- a/SteamclEnv-Example/Environment.swift
+++ b/SteamclEnv-Example/Environment.swift
@@ -1,5 +1,16 @@
 // @generated
 //  This file was automatically generated and should not be edited.
 enum Environment {
-    static let API_URL = "https://bing.com" 
+    private static let salt: [UInt8] = [86, 49, 191, 181, 18, 159, 126, 44]
+
+    private static func decode(_ encoded: [UInt8]) -> String {
+      String(decoding: encoded.enumerated().map { (offset, element) in
+              element ^ salt[offset % salt.count]
+          }, as: UTF8.self
+      )
+    }
+    static var API_URL: String {
+        let encoded: [UInt8] = [62, 69, 203, 197, 97, 165, 81, 3, 49, 94, 208, 210, 126, 250, 80, 79, 57, 92]
+        return decode(encoded)
+    }
 }

--- a/SteamclEnv-Example/SteamclEnv-Example.xcodeproj/project.pbxproj
+++ b/SteamclEnv-Example/SteamclEnv-Example.xcodeproj/project.pbxproj
@@ -165,7 +165,7 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "./steamclenv generate --dev\n";
+			shellScript = "./steamclenv generate --obfuscate\n";
 		};
 /* End PBXShellScriptBuildPhase section */
 


### PR DESCRIPTION
For #6 

Adds:
- the --obfuscate tag, which allows you to toggle value obfuscation.
- cleans up the logging logic a little, moving the check for debug to a singleton rather than having to pass our debug setting around into our helper models.

Questions:
- Do we maybe want to flip the logic here and just obfuscate by default?
- @nbrooke I tried to google around a little to understand how Swift apps get compiled and what the executable ends up looking like, but wasn't able to get a really satisfying answer, but I'm really curious how secure this actually is? 

Like we're providing the salt right in the same file, so theoretically all the information you need to decrypt the values are right there. I know security by obfuscation isn't supposed to be rock solid, but am mostly just curious how much of a different this makes.